### PR TITLE
fix: incorrect category default size list

### DIFF
--- a/lib/app/modules/filter/filter_page.dart
+++ b/lib/app/modules/filter/filter_page.dart
@@ -255,7 +255,7 @@ class _FilterPageState extends ModularState<FilterPage, FilterController> {
     return ExpansionPanel(
       headerBuilder: (BuildContext context, bool isExpanded) {
         return header(_data[5], onTap: (Item item) {
-          item.booleans = List.filled(6, false);
+          item.booleans = List.filled(17, false);
         });
       },
       body: Column(


### PR DESCRIPTION
Tamanho padão da lista de categorias quando zerada estava incorreto, gerando erro ao limpar a lista de categorias no filtro.